### PR TITLE
Trigger downstream noso-docker workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -85,3 +85,14 @@ jobs:
             noso-*.tgz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Trigger Downstream
+        run: |
+          tag=${{ github.event.ref }}
+          tag=${tag#"refs/tags/"}
+          curl \
+            -XPOST \
+            -u "leviable:${{ secrets.NOSO_DOCKER_PAT }}" \
+            -H "Accept: application/vnd.github.everest-preview+json" \
+            -H "Content-Type: application/json" \
+            --data '{"ref": "main", "inputs": {"noso_tag": "'"${tag}"'"}}' \
+            https://api.github.com/repos/Noso-Project/noso-docker/actions/workflows/main.yaml/dispatches


### PR DESCRIPTION
When a NosoWallet release is created, trigger the downstream `noso-docker` repo to build a new containerized version of the Noso wallet.